### PR TITLE
feat: configure excluded repositories and commands

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -19,6 +19,15 @@ import { extractCommaSeparated, extractUsersAndTeams } from "./converters.js";
 
 export async function router(auth, id, payload, verbose) {
   const sourceRepo = payload.repository.name;
+
+  const excludedRepositories = process.env.EXCLUDED_REPOSITORIES.split(',')
+  if (excludedRepositories.includes(sourceRepo)) {
+    console.log(
+      `This ${sourceRepo} repository is excluded from github-comment-ops`
+    );
+    return;
+  }
+
   const transferMatches = transferMatcher(payload.comment.body);
   const actorRequest = `as requested by ${payload.sender.login}`;
   if (transferMatches) {


### PR DESCRIPTION
Ref: https://github.com/timja/github-comment-ops/issues/54

I'm proposing to define excluded repositories with an env var containing the list of excluded repositories separated by a comma.

(PR in draft, need to add the corresponding value to the chart)

To exclude a repo, an help desk issue could be opened to add the repo name to this env var.

WDYT @timja @dduportal @daniel-beck 