### PR TITLE
Cleanup error logging

### DIFF
--- a/app/commands/close-command.js
+++ b/app/commands/close-command.js
@@ -35,6 +35,20 @@ export class CloseCommand extends Command {
     logger.info(
       `Closing issue ${this.payload.issue.html_url}, reason: ${reason}`
     );
-    await closeIssue(authToken, sourceRepo, this.payload.issue.node_id, reason);
+    try {
+      await closeIssue(
+        authToken,
+        sourceRepo,
+        this.payload.issue.node_id,
+        reason
+      );
+    } catch (error) {
+      logger.error(
+        `Failed to close issue ${
+          error.errors ? JSON.stringify(error.errors) : ""
+        }`,
+        error
+      );
+    }
   }
 }

--- a/app/commands/label-command.js
+++ b/app/commands/label-command.js
@@ -34,12 +34,21 @@ export class LabelCommand extends Command {
     logger.info(
       `Labeling issue ${this.payload.issue.html_url} with labels ${labels}`
     );
-    await addLabel(
-      authToken,
-      this.payload.repository.owner.login,
-      sourceRepo,
-      this.payload.issue.node_id,
-      labels
-    );
+    try {
+      await addLabel(
+        authToken,
+        this.payload.repository.owner.login,
+        sourceRepo,
+        this.payload.issue.node_id,
+        labels
+      );
+    } catch (error) {
+      logger.error(
+        `Failed to add label ${
+          error.errors ? JSON.stringify(error.errors) : ""
+        }`,
+        error
+      );
+    }
   }
 }

--- a/app/commands/remove-label-command.js
+++ b/app/commands/remove-label-command.js
@@ -33,12 +33,21 @@ export class RemoveLabelCommand extends Command {
     logger.info(
       `Removing label(s) from issue ${this.payload.issue.html_url}, labels ${labels}`
     );
-    await removeLabel(
-      authToken,
-      this.payload.repository.owner.login,
-      sourceRepo,
-      this.payload.issue.node_id,
-      labels
-    );
+    try {
+      await removeLabel(
+        authToken,
+        this.payload.repository.owner.login,
+        sourceRepo,
+        this.payload.issue.node_id,
+        labels
+      );
+    } catch (error) {
+      logger.error(
+        `Failed to remove label ${
+          error.errors ? JSON.stringify(error.errors) : ""
+        }`,
+        error
+      );
+    }
   }
 }

--- a/app/commands/reopen-command.js
+++ b/app/commands/reopen-command.js
@@ -29,6 +29,15 @@ export class ReopenCommand extends Command {
 
     logger.info(`Re-opening issue ${this.payload.issue.html_url}`);
 
-    await reopenIssue(authToken, sourceRepo, this.payload.issue.node_id);
+    try {
+      await reopenIssue(authToken, sourceRepo, this.payload.issue.node_id);
+    } catch (error) {
+      logger.error(
+        `Failed to reopen issue ${
+          error.errors ? JSON.stringify(error.errors) : ""
+        }`,
+        error
+      );
+    }
   }
 }

--- a/app/commands/reviewer-command.js
+++ b/app/commands/reviewer-command.js
@@ -36,13 +36,22 @@ export class ReviewerCommand extends Command {
       this.payload.repository.owner.login,
       reviewerMatches
     );
-    await requestReviewers(
-      authToken,
-      this.payload.repository.owner.login,
-      sourceRepo,
-      this.payload.issue.node_id,
-      reviewers.users,
-      reviewers.teams
-    );
+    try {
+      await requestReviewers(
+        authToken,
+        this.payload.repository.owner.login,
+        sourceRepo,
+        this.payload.issue.node_id,
+        reviewers.users,
+        reviewers.teams
+      );
+    } catch (error) {
+      logger.error(
+        `Failed to request reviewer ${
+          error.errors ? JSON.stringify(error.errors) : ""
+        }`,
+        error
+      );
+    }
   }
 }

--- a/app/commands/transfer-command.js
+++ b/app/commands/transfer-command.js
@@ -31,12 +31,21 @@ export class TransferCommand extends Command {
     logger.info(
       `Transferring issue ${this.payload.issue.html_url} to repo ${targetRepo}`
     );
-    await transferIssue(
-      authToken,
-      this.payload.repository.owner.login,
-      sourceRepo,
-      targetRepo,
-      this.payload.issue.node_id
-    );
+    try {
+      await transferIssue(
+        authToken,
+        this.payload.repository.owner.login,
+        sourceRepo,
+        targetRepo,
+        this.payload.issue.node_id
+      );
+    } catch (error) {
+      logger.error(
+        `Failed to transfer issue ${
+          error.errors ? JSON.stringify(error.errors) : ""
+        }`,
+        error
+      );
+    }
   }
 }

--- a/app/default-config.js
+++ b/app/default-config.js
@@ -11,6 +11,9 @@ export const defaultConfig = {
     reopen: {
       enabled: true,
     },
+    close: {
+      enabled: true,
+    },
     reviewer: {
       enabled: true,
     },

--- a/app/github.js
+++ b/app/github.js
@@ -18,47 +18,41 @@ async function convertLabelsToIds(labels, token, login, repository) {
 }
 
 export async function addLabel(token, login, repository, labelableId, labels) {
-  try {
-    const { invalidLabels, labelIds } = await convertLabelsToIds(
-      labels,
-      token,
-      login,
-      repository
-    );
+  const { invalidLabels, labelIds } = await convertLabelsToIds(
+    labels,
+    token,
+    login,
+    repository
+  );
 
-    await graphql(
-      `
-        mutation ($labelableId: ID!, $labelIds: [ID!]!) {
-          addLabelsToLabelable(
-            input: { labelableId: $labelableId, labelIds: $labelIds }
-          ) {
-            clientMutationId
-          }
+  await graphql(
+    `
+      mutation ($labelableId: ID!, $labelIds: [ID!]!) {
+        addLabelsToLabelable(
+          input: { labelableId: $labelableId, labelIds: $labelIds }
+        ) {
+          clientMutationId
         }
-      `,
-      {
-        labelableId,
-        labelIds,
-        headers: {
-          authorization: `token ${token}`,
-        },
       }
-    );
+    `,
+    {
+      labelableId,
+      labelIds,
+      headers: {
+        authorization: `token ${token}`,
+      },
+    }
+  );
 
-    if (invalidLabels.length > 0) {
-      const comment = `I wasn't able to add the following labels: ${invalidLabels.join(
-        ","
-      )}
+  if (invalidLabels.length > 0) {
+    const comment = `I wasn't able to add the following labels: ${invalidLabels.join(
+      ","
+    )}
 
 Check that [the label exists](https://github.com/${login}/${repository}/labels) and is spelt right then try again.
       `;
 
-      await reportError(token, labelableId, comment);
-    }
-  } catch (error) {
-    console.error("Failed to add label", error);
-
-    console.error(JSON.stringify(error.errors));
+    await reportError(token, labelableId, comment);
   }
 }
 
@@ -104,47 +98,41 @@ export async function removeLabel(
   labelableId,
   labels
 ) {
-  try {
-    const { invalidLabels, labelIds } = await convertLabelsToIds(
-      labels,
-      token,
-      login,
-      repository
-    );
+  const { invalidLabels, labelIds } = await convertLabelsToIds(
+    labels,
+    token,
+    login,
+    repository
+  );
 
-    await graphql(
-      `
-        mutation ($labelableId: ID!, $labelIds: [ID!]!) {
-          removeLabelsFromLabelable(
-            input: { labelableId: $labelableId, labelIds: $labelIds }
-          ) {
-            clientMutationId
-          }
+  await graphql(
+    `
+      mutation ($labelableId: ID!, $labelIds: [ID!]!) {
+        removeLabelsFromLabelable(
+          input: { labelableId: $labelableId, labelIds: $labelIds }
+        ) {
+          clientMutationId
         }
-      `,
-      {
-        labelableId,
-        labelIds,
-        headers: {
-          authorization: `token ${token}`,
-        },
       }
-    );
+    `,
+    {
+      labelableId,
+      labelIds,
+      headers: {
+        authorization: `token ${token}`,
+      },
+    }
+  );
 
-    if (invalidLabels.length > 0) {
-      const comment = `I wasn't able to remove the following labels: ${invalidLabels.join(
-        ","
-      )}
+  if (invalidLabels.length > 0) {
+    const comment = `I wasn't able to remove the following labels: ${invalidLabels.join(
+      ","
+    )}
 
 Check that [the label exists](https://github.com/${login}/${repository}/labels) and is spelt right then try again.
       `;
 
-      await reportError(token, labelableId, comment);
-    }
-  } catch (error) {
-    console.error("Failed to add label", error);
-
-    console.error(JSON.stringify(error.errors));
+    await reportError(token, labelableId, comment);
   }
 }
 
@@ -212,33 +200,27 @@ async function lookupTeam(token, organization, teamName, originalTeamName) {
 }
 
 export async function addReaction(token, subjectId, content) {
-  try {
-    await graphql(
-      `
-        mutation ($subjectId: ID!, $content: ReactionContent!) {
-          addReaction(input: { subjectId: $subjectId, content: $content }) {
-            reaction {
-              content
-            }
-            subject {
-              id
-            }
+  await graphql(
+    `
+      mutation ($subjectId: ID!, $content: ReactionContent!) {
+        addReaction(input: { subjectId: $subjectId, content: $content }) {
+          reaction {
+            content
+          }
+          subject {
+            id
           }
         }
-      `,
-      {
-        subjectId,
-        content,
-        headers: {
-          authorization: `token ${token}`,
-        },
       }
-    );
-  } catch (error) {
-    console.error("Failed to add reaction", error);
-
-    console.error(JSON.stringify(error.errors));
-  }
+    `,
+    {
+      subjectId,
+      content,
+      headers: {
+        authorization: `token ${token}`,
+      },
+    }
+  );
 }
 
 export async function reportError(token, subjectId, comment) {
@@ -265,29 +247,23 @@ export async function reportError(token, subjectId, comment) {
 }
 
 export async function reopenIssue(token, sourceRepo, issueId) {
-  try {
-    await graphql(
-      `
-        mutation ($issue: ID!) {
-          reopenIssue(input: { issueId: $issue }) {
-            issue {
-              url
-            }
+  await graphql(
+    `
+      mutation ($issue: ID!) {
+        reopenIssue(input: { issueId: $issue }) {
+          issue {
+            url
           }
         }
-      `,
-      {
-        issue: issueId,
-        headers: {
-          authorization: `token ${token}`,
-        },
       }
-    );
-  } catch (error) {
-    console.error("Failed to reopen issue", error);
-
-    console.error(JSON.stringify(error.errors));
-  }
+    `,
+    {
+      issue: issueId,
+      headers: {
+        authorization: `token ${token}`,
+      },
+    }
+  );
 }
 
 export async function requestReviewers(
@@ -298,127 +274,115 @@ export async function requestReviewers(
   users,
   teams
 ) {
-  try {
-    const convertedUsers = await Promise.all(
-      users
-        .map((user) => {
-          return {
-            original_user: user,
-            user: user.replace(/^@/, ""),
-          };
-        })
-        .map(
-          async (result) =>
-            await lookupUser(token, result.user, result.original_user)
-        )
-    );
+  const convertedUsers = await Promise.all(
+    users
+      .map((user) => {
+        return {
+          original_user: user,
+          user: user.replace(/^@/, ""),
+        };
+      })
+      .map(
+        async (result) =>
+          await lookupUser(token, result.user, result.original_user)
+      )
+  );
 
-    const invalidUsers = convertedUsers
-      .filter((result) => result.err !== undefined)
-      .map((result) => result.user);
+  const invalidUsers = convertedUsers
+    .filter((result) => result.err !== undefined)
+    .map((result) => result.user);
 
-    const userIds = convertedUsers
-      .filter((result) => result.id !== undefined)
-      .map((result) => result.id);
+  const userIds = convertedUsers
+    .filter((result) => result.id !== undefined)
+    .map((result) => result.id);
 
-    const convertedTeams = await Promise.all(
-      teams
-        .map((teamSlug) => {
-          return {
-            original_team: teamSlug,
-            team: teamSlug.replace(`@${organization}/`, ""),
-          };
-        })
-        .map(
-          async (result) =>
-            await lookupTeam(
-              token,
-              organization,
-              result.team,
-              result.original_team
-            )
-        )
-    );
+  const convertedTeams = await Promise.all(
+    teams
+      .map((teamSlug) => {
+        return {
+          original_team: teamSlug,
+          team: teamSlug.replace(`@${organization}/`, ""),
+        };
+      })
+      .map(
+        async (result) =>
+          await lookupTeam(
+            token,
+            organization,
+            result.team,
+            result.original_team
+          )
+      )
+  );
 
-    const invalidTeams = convertedTeams
-      .filter((result) => result.err !== undefined)
-      .map((result) => result.team);
+  const invalidTeams = convertedTeams
+    .filter((result) => result.err !== undefined)
+    .map((result) => result.team);
 
-    const teamIds = convertedTeams
-      .filter((result) => result.id !== undefined)
-      .map((result) => result.id);
+  const teamIds = convertedTeams
+    .filter((result) => result.id !== undefined)
+    .map((result) => result.id);
 
-    await graphql(
-      `
-        mutation ($pullRequestId: ID!, $userIds: [ID!]!, $teamIds: [ID!]!) {
-          requestReviews(
-            input: {
-              pullRequestId: $pullRequestId
-              userIds: $userIds
-              teamIds: $teamIds
-              union: true
-            }
-          ) {
-            pullRequest {
-              url
-            }
+  await graphql(
+    `
+      mutation ($pullRequestId: ID!, $userIds: [ID!]!, $teamIds: [ID!]!) {
+        requestReviews(
+          input: {
+            pullRequestId: $pullRequestId
+            userIds: $userIds
+            teamIds: $teamIds
+            union: true
+          }
+        ) {
+          pullRequest {
+            url
           }
         }
-      `,
-      {
-        pullRequestId: issueId,
-        userIds,
-        teamIds,
-        headers: {
-          authorization: `token ${token}`,
-        },
       }
-    );
+    `,
+    {
+      pullRequestId: issueId,
+      userIds,
+      teamIds,
+      headers: {
+        authorization: `token ${token}`,
+      },
+    }
+  );
 
-    if (invalidUsers.length > 0 || invalidTeams.length > 0) {
-      const invalidReviewers = [...invalidUsers, ...invalidTeams];
+  if (invalidUsers.length > 0 || invalidTeams.length > 0) {
+    const invalidReviewers = [...invalidUsers, ...invalidTeams];
 
-      const comment = `I wasn't able to request review for the following reviewer(s): ${invalidReviewers.join(
-        ","
-      )}
+    const comment = `I wasn't able to request review for the following reviewer(s): ${invalidReviewers.join(
+      ","
+    )}
 
 Check that the reviewer is spelt right and try again.
       `;
 
-      await reportError(token, issueId, comment);
-    }
-  } catch (error) {
-    console.error("Failed to request reviewers", error);
-
-    console.error(JSON.stringify(error.errors));
+    await reportError(token, issueId, comment);
   }
 }
 
 export async function closeIssue(token, sourceRepo, issueId, reason) {
-  try {
-    await graphql(
-      `
-        mutation ($issue: ID!, $stateReason: IssueClosedStateReason) {
-          closeIssue(input: { issueId: $issue, stateReason: $stateReason }) {
-            issue {
-              url
-            }
+  await graphql(
+    `
+      mutation ($issue: ID!, $stateReason: IssueClosedStateReason) {
+        closeIssue(input: { issueId: $issue, stateReason: $stateReason }) {
+          issue {
+            url
           }
         }
-      `,
-      {
-        issue: issueId,
-        stateReason: reason,
-        headers: {
-          authorization: `token ${token}`,
-        },
       }
-    );
-  } catch (error) {
-    console.error("Failed to close issue", error);
-
-    console.error(JSON.stringify(error.errors));
-  }
+    `,
+    {
+      issue: issueId,
+      stateReason: reason,
+      headers: {
+        authorization: `token ${token}`,
+      },
+    }
+  );
 }
 
 export async function transferIssue(
@@ -428,45 +392,39 @@ export async function transferIssue(
   targetRepo,
   issueId
 ) {
-  try {
-    const { target } = await graphql(
-      `
-        query ($owner: String!, $targetRepo: String!) {
-          target: repository(owner: $owner, name: $targetRepo) {
-            id
+  const { target } = await graphql(
+    `
+      query ($owner: String!, $targetRepo: String!) {
+        target: repository(owner: $owner, name: $targetRepo) {
+          id
+        }
+      }
+    `,
+    {
+      owner,
+      targetRepo,
+      headers: {
+        authorization: `token ${token}`,
+      },
+    }
+  );
+
+  await graphql(
+    `
+      mutation ($issue: ID!, $repo: ID!) {
+        transferIssue(input: { issueId: $issue, repositoryId: $repo }) {
+          issue {
+            url
           }
         }
-      `,
-      {
-        owner,
-        targetRepo,
-        headers: {
-          authorization: `token ${token}`,
-        },
       }
-    );
-
-    await graphql(
-      `
-        mutation ($issue: ID!, $repo: ID!) {
-          transferIssue(input: { issueId: $issue, repositoryId: $repo }) {
-            issue {
-              url
-            }
-          }
-        }
-      `,
-      {
-        issue: issueId,
-        repo: target.id,
-        headers: {
-          authorization: `token ${token}`,
-        },
-      }
-    );
-  } catch (error) {
-    console.error("Failed to transfer issue", error);
-
-    console.error(JSON.stringify(error.errors));
-  }
+    `,
+    {
+      issue: issueId,
+      repo: target.id,
+      headers: {
+        authorization: `token ${token}`,
+      },
+    }
+  );
 }

--- a/app/router.js
+++ b/app/router.js
@@ -31,7 +31,16 @@ export async function router(auth, id, payload, verbose) {
 
   try {
     await addReaction(authToken, payload.comment.node_id, "THUMBS_UP");
+  } catch (error) {
+    logger.error(
+      `Failed to add reaction ${
+        error.errors ? JSON.stringify(error.errors) : ""
+      }`,
+      error
+    );
+  }
 
+  try {
     // TODO validate against schema
     // noinspection JSUnusedGlobalSymbols
     const { config } = await octokit.config.get({


### PR DESCRIPTION
- Remove console.error
- Don't fail action if reactions are broken

Logging done at the command level so we don't need to pass ID and user down to `github` level

relates to https://github.com/timja/github-comment-ops/issues/59