### PR TITLE
Disable commands by default

### DIFF
--- a/.github/comment-ops.yml
+++ b/.github/comment-ops.yml
@@ -1,0 +1,13 @@
+commands:
+  label:
+    enabled: true
+  removeLabel:
+    enabled: true
+  reopen:
+    enabled: true
+  close:
+    enabled: true
+  reviewer:
+    enabled: true
+  transfer:
+    enabled: false

--- a/README.md
+++ b/README.md
@@ -7,30 +7,33 @@ GitHub apps are used for authentication to limit the required permissions.
 
 ## Configuration
 
-The app can be configured with a `.github/comment-ops.yml` file in the main branch of the repository.
-
+The app is configured with a `.github/comment-ops.yml` file in the main branch of the repository.
 This can also be applied organization wide by creating it in the organization's `.github` repository.
+
+_Note: This file is required all commands are disabled by default._
 
 The order of configuration is:
 
-`default config` -> `organization` -> `repository`
+`default config` → `organization` → `repository`
 
 Default configuration:
 
 ```yaml
 commands:
+  close:
+    enabled: false
   label:
     allowedLabels: [] # any label is allowed
-    enabled: true
+    enabled: false
   removeLabel:
     allowedLabels: [] # any label is allowed
-    enabled: true
+    enabled: false
   reopen:
-    enabled: true
+    enabled: false
   reviewer:
-    enabled: true
+    enabled: false
   transfer:
-    enabled: true
+    enabled: false
 ```
 
 ## Getting started

--- a/app/default-config.js
+++ b/app/default-config.js
@@ -2,23 +2,23 @@ export const defaultConfig = {
   commands: {
     label: {
       allowedLabels: [],
-      enabled: true,
+      enabled: false,
     },
     removeLabel: {
       allowedLabels: [],
-      enabled: true,
+      enabled: false,
     },
     reopen: {
-      enabled: true,
+      enabled: false,
     },
     close: {
-      enabled: true,
+      enabled: false,
     },
     reviewer: {
-      enabled: true,
+      enabled: false,
     },
     transfer: {
-      enabled: true,
+      enabled: false,
     },
   },
 };


### PR DESCRIPTION
Fixes https://github.com/timja/github-comment-ops/issues/69

This will be safer so that new commands can be added without worrying anyone and installing the app won't do anything out of the box without configuration being added

FYI @lemeurherve 