### PR TITLE
Remove badges - makes releases a bit easier

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.9.1
+          version: v3.13.2
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0

--- a/charts/github-comment-ops/README.md
+++ b/charts/github-comment-ops/README.md
@@ -1,7 +1,5 @@
 # github-comment-ops
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.4.0](https://img.shields.io/badge/AppVersion-v1.4.0-informational?style=flat-square)
-
 A tool for managing GitHub issues and pull requests via comment-ops. It uses GitHub webhooks to scale across repositories without needing to add a GitHub action to each of them.
 
 ## Chart deployment

--- a/charts/github-comment-ops/README.md.gotmpl
+++ b/charts/github-comment-ops/README.md.gotmpl
@@ -1,8 +1,6 @@
 {{ template "chart.header" . }}
 {{ template "chart.deprecationWarning" . }}
 
-{{ template "chart.badgesSection" . }}
-
 {{ template "chart.description" . }}
 
 {{ template "chart.homepageLine" . }}


### PR DESCRIPTION
This means I don't need to run helm docs locally to update the chart readme when releasing the chart.
Ideally it would be setup to publish helm on tag push but I haven't had time to do that yet